### PR TITLE
Opthimo/fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Download the image files into the `figures/` subdirectory using `curl`:
 
 ```bash
 curl -o figures/picture.png https://raw.githubusercontent.com/STEMgraph/66726805-4497-4dce-a1ba-ccf930a721f8/master/assets/picture.png
-curl -o figures/chart.png https://raw.githubusercontent.com/Opthimo/LaTeX-Inserting-Figures/master/assets/chart.png
+curl -o figures/chart.png https://raw.githubusercontent.com/STEMgraph/66726805-4497-4dce-a1ba-ccf930a721f8/master/assets/chart.png
 ```
 
 Then, create an empty LaTeX source file inside `src/` with the touch command:

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ mkdir -p src figures
 Download the image files into the `figures/` subdirectory using `curl`:
 
 ```bash
-curl -o figures/picture.png https://github.com/STEMgraph/66726805-4497-4dce-a1ba-ccf930a721f8/blob/master/assets/picture.png?raw=true
-curl -o figures/chart.png https://github.com/STEMgraph/66726805-4497-4dce-a1ba-ccf930a721f8/blob/master/assets/chart.png?raw=true
+curl -o figures/picture.png https://raw.githubusercontent.com/STEMgraph/66726805-4497-4dce-a1ba-ccf930a721f8/master/assets/picture.png
+curl -o figures/chart.png https://raw.githubusercontent.com/Opthimo/LaTeX-Inserting-Figures/master/assets/chart.png
 ```
 
 Then, create an empty LaTeX source file inside `src/` with the touch command:


### PR DESCRIPTION
Fixes #1 

This pull request replaces the broken GitHub `blob` links in the curl commands with proper `raw.githubusercontent.com` links. 
The updated links now allow downloading the images directly via curl.